### PR TITLE
Fallback to empty string as Rails 5.1 can't handle nil paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.35.1
+* Fix bug with Rails 5.1 when calling recognize_path with a nil path
+
 # 0.35.0
 * removes record_on_server_receive option
 * records status_code and method on all server receive events.

--- a/lib/zipkin-tracer/application.rb
+++ b/lib/zipkin-tracer/application.rb
@@ -4,7 +4,7 @@ module ZipkinTracer
     # Determines if our framework knows whether the request will be routed to a controller
     def self.routable_request?(env)
       return true unless defined?(Rails) # If not running on a Rails app, we can't verify if it is invalid
-      path_info = env[ZipkinTracer::RackHandler::PATH_INFO]
+      path_info = env[ZipkinTracer::RackHandler::PATH_INFO] || ""
       http_method = env[ZipkinTracer::RackHandler::REQUEST_METHOD]
       Rails.application.routes.recognize_path(path_info, method: http_method)
       true

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.35.0'.freeze
+  VERSION = '0.35.1'.freeze
 end


### PR DESCRIPTION
In Rails 5.1 (specifically actionpack), there is an issue where passing an empty path to `Rails.application.routes.recognize_path` results in a `NoMethodError: undefined method `encoding' for nil:NilClass` exception being thrown.

See: https://github.com/rails/rails/commit/03925dc26a747075ff37660d1f0a060a8178bf66

I'm unsure why this issue did not occur prior to https://github.com/openzipkin/zipkin-ruby/pull/143 though. Seems like the same problem should occur, but doesn't 🤷‍♂️ 